### PR TITLE
PRE-15562 | Integrator-extension version change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "body-parser": "1.20.3",
         "express": "4.21.1",
         "express-winston": "2.5.1",
-        "integrator-extension": "0.3.11",
+        "integrator-extension": "0.3.12",
         "nanoid": "3.3.4",
         "winston": "2.2.0"
       },
@@ -1046,9 +1046,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/integrator-extension": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/integrator-extension/-/integrator-extension-0.3.11.tgz",
-      "integrity": "sha512-fRnKHdB+mIuMtfypHXJKOVZLeC+oWQdEjYwYhrVb3dk3TMKHZUWfNVTTAGlxICyLqim5BqZCobQ63BIgV9FlIQ==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/integrator-extension/-/integrator-extension-0.3.12.tgz",
+      "integrity": "sha512-oqhxPYQn8XbA3x6rJssNq8uB7CvV3/OignLZUPcWks3W2l9UFl+/ibo/uPUcm4M4cH2ZYOfZnXUVtnPrluMiMA==",
       "dependencies": {
         "lodash.isempty": "4.4.0",
         "lodash.isplainobject": "4.0.6"
@@ -3022,9 +3022,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "integrator-extension": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/integrator-extension/-/integrator-extension-0.3.11.tgz",
-      "integrity": "sha512-fRnKHdB+mIuMtfypHXJKOVZLeC+oWQdEjYwYhrVb3dk3TMKHZUWfNVTTAGlxICyLqim5BqZCobQ63BIgV9FlIQ==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/integrator-extension/-/integrator-extension-0.3.12.tgz",
+      "integrity": "sha512-oqhxPYQn8XbA3x6rJssNq8uB7CvV3/OignLZUPcWks3W2l9UFl+/ibo/uPUcm4M4cH2ZYOfZnXUVtnPrluMiMA==",
       "requires": {
         "lodash.isempty": "4.4.0",
         "lodash.isplainobject": "4.0.6"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-integrator-extension",
   "main": "./lib/server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Express based extension for Integrator.io",
   "homepage": "https://integrator.io",
   "author": "Celigo Inc. <developer@celigo.com> (http://www.celigo.com)",
@@ -17,7 +17,7 @@
     "body-parser": "1.20.3",
     "express": "4.21.1",
     "express-winston": "2.5.1",
-    "integrator-extension": "0.3.11",
+    "integrator-extension": "0.3.12",
     "nanoid": "3.3.4",
     "winston": "2.2.0"
   },


### PR DESCRIPTION
This pull request includes updates to the `package.json` file to increment the version of the `express-integrator-extension` package and update the dependency version for `integrator-extension`.

Version updates:

* Updated the `version` of the `express-integrator-extension` package from `0.3.0` to `0.3.1`.
* Updated the `integrator-extension` dependency version from `0.3.11` to `0.3.12`.

Reference PR : https://github.com/celigo/integrator-extension/pull/106